### PR TITLE
Restrict admin role editing and update sidebar label

### DIFF
--- a/src/app/(pages)/(admin)/layout.tsx
+++ b/src/app/(pages)/(admin)/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   const pathname = usePathname();
   const isActive = (path: string) => pathname === path;
   const router = useRouter();
-  const { signOut } = useAuth();
+  const { signOut, userRole } = useAuth();
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   const handleNavigation = (path: string) => {
@@ -38,7 +38,7 @@ export default function RootLayout({
         <div className="hidden md:flex flex-col justify-between w-[200px] h-full bg-[#333446]">
           <div>
             <h1 className="p-[10px] font-semibold text-[#FE5D26] mb-[8px] self-center text-[18px]">
-              Admin
+              {userRole === 1 ? 'Admin' : 'Staff'}
             </h1>
 
             <ul className="flex flex-col gap-[16px] text-[#3D3C42] w-full">

--- a/src/components/UserModal.tsx
+++ b/src/components/UserModal.tsx
@@ -179,23 +179,25 @@ export function UserModal({ open, onOpenChange, onSubmit, editingUser }: UserMod
               />
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="role">Role *</Label>
-              <Select
-                value={formData.role.toString()}
-                onValueChange={(value) => handleInputChange('role', parseInt(value))}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select a role" />
-                </SelectTrigger>
-                <SelectContent>
-                  {/* Only show Admin option to actual admins */}
-                  {userRole === 1 && <SelectItem value="1">Admin</SelectItem>}
-                  <SelectItem value="2">Staff</SelectItem>
-                  <SelectItem value="3">User</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            {editingUser ? null : (
+              <div className="space-y-2">
+                <Label htmlFor="role">Role *</Label>
+                <Select
+                  value={formData.role.toString()}
+                  onValueChange={(value) => handleInputChange('role', parseInt(value))}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select a role" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {/* Only show Admin option to actual admins */}
+                    {userRole === 1 && <SelectItem value="1">Admin</SelectItem>}
+                    <SelectItem value="2">Staff</SelectItem>
+                    <SelectItem value="3">User</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label htmlFor="status">Status</Label>

--- a/src/components/UserTable.tsx
+++ b/src/components/UserTable.tsx
@@ -128,10 +128,12 @@ export function UserTable({ users, onEdit, onDelete, onStatusChange }: UserTable
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={() => onEdit?.(user)}>
-                      <Edit className="h-4 w-4 mr-2" />
-                      Edit
-                    </DropdownMenuItem>
+                    {user.role !== 1 ? (
+                      <DropdownMenuItem onClick={() => onEdit?.(user)}>
+                        <Edit className="h-4 w-4 mr-2" />
+                        Edit
+                      </DropdownMenuItem>
+                    ) : null}
                     {user.status !== 'ACTIVE' && (
                       <DropdownMenuItem onClick={() => onStatusChange?.(user.id, 'ACTIVE')}>
                         <UserCheck className="h-4 w-4 mr-2" />


### PR DESCRIPTION
Hides the role selection field in UserModal when editing an existing user, preventing role changes. Updates sidebar label to show 'Admin' or 'Staff' based on userRole. Disables editing for users with the admin role in UserTable.